### PR TITLE
Run tests script can read from keychain for the client token

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,15 @@ To run the tests:
 ```shell
 ./scripts/run_tests.sh <CLIENT_TOKEN>
 ```
+
+Alternatively, you can store the client token in your local keychain, allowing you to run the shell script without any parameters.
+
+To store the token, run the following (replacing `CLIENT_TOKEN`):
+```shell
+security add-generic-password -s 'Swift Provider - E2E Tests'  -a 'konfidens-e2e' -w 'CLIENT_TOKEN'
+```
+
+You can then run the script as follows (note: you may need to allow access to the keychain on the first run):
+```shell
+./scripts/run_tests.sh
+```

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,8 +5,16 @@ set -e
 script_dir=$(dirname $0)
 root_dir="$script_dir/../"
 
+# Set the client token in your local keychain using the following command:
+# security add-generic-password -s 'Swift Provider - E2E Tests'  -a 'konfidens-e2e' -w 'TOKEN'
+# You can then run the script with no arguments - you will need to allow access the first time only.
+test_runner_client_token=$1
+if [[ -z "${test_runner_client_token// }" ]]; then
+    test_runner_client_token=$(security find-generic-password -w -s 'Swift Provider - E2E Tests' -a 'konfidens-e2e')
+fi
+
 (cd $root_dir &&
-    TEST_RUNNER_CLIENT_TOKEN=$1 TEST_RUNNER_TEST_FLAG_NAME=$2 xcodebuild \
+    TEST_RUNNER_CLIENT_TOKEN=$test_runner_client_token TEST_RUNNER_TEST_FLAG_NAME=$2 xcodebuild \
         -scheme ConfidenceProvider \
         -sdk "iphonesimulator" \
         -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' \


### PR DESCRIPTION
Use this command to store the token:
`security add-generic-password -s 'Swift Provider - E2E Tests'  -a 'konfidens-e2e' -w 'CLIENT_TOKEN'`