### PR TITLE
ci: Update IntegrationTest flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         ssh-private-key: ${{ secrets.SDK_REPO_PRIVATE_KEY }}
     - name: Build and Test
       env:
-        CLIENT_TOKEN: ${{ secrets.KONFIDENS_CLIENT_TOKEN }}
+        CLIENT_TOKEN: ${{ secrets.CONFIDENCE_CLIENT_TOKEN }}
       run: scripts/run_tests.sh $CLIENT_TOKEN
 
   SwiftLint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ You can automatically format your code using:
 ### Running tests
 
 IT tests require a Confidence client token to reach remote servers. The token can be created on the Confidence portal. 
-The Confidence organization used for IT tests is named `konfidens-e2e` (you may need to request access).
+The Confidence organization used for IT tests is named `confidence-test` (you may need to request access).
 
-The tests use the flag `test-flag-1` and the client key can be found under `Swift Provider - E2E Tests` in the console.
+The tests use the flag `swift-flag-test` and the enabled client name is `swift-provider-e2e`.
 
 To run the tests:
 
@@ -36,7 +36,7 @@ Alternatively, you can store the client token in your local keychain, allowing y
 
 To store the token, run the following (replacing `CLIENT_TOKEN`):
 ```shell
-security add-generic-password -s 'Swift Provider - E2E Tests'  -a 'konfidens-e2e' -w 'CLIENT_TOKEN'
+security add-generic-password -s 'swift-provider-e2e'  -a 'confidence-test' -w 'CLIENT_TOKEN'
 ```
 
 You can then run the script as follows (note: you may need to allow access to the keychain on the first run):

--- a/Tests/ConfidenceProviderTests/ConfidenceIntegrationTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceIntegrationTest.swift
@@ -13,7 +13,7 @@ class ConfidenceIntegrationTests: XCTestCase {
         if let flag = ProcessInfo.processInfo.environment["TEST_FLAG_NAME"], !flag.isEmpty {
             return flag
         }
-        return "test-flag-1"
+        return "swift-test-flag"
     }
 
     override func setUp() async throws {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,11 +6,11 @@ script_dir=$(dirname $0)
 root_dir="$script_dir/../"
 
 # Set the client token in your local keychain using the following command:
-# security add-generic-password -s 'Swift Provider - E2E Tests'  -a 'konfidens-e2e' -w 'TOKEN'
+# security add-generic-password -s 'swift-provider-e2e'  -a 'confidence-test' -w 'TOKEN'
 # You can then run the script with no arguments - you will need to allow access the first time only.
 test_runner_client_token=$1
 if [[ -z "${test_runner_client_token// }" ]]; then
-    test_runner_client_token=$(security find-generic-password -w -s 'Swift Provider - E2E Tests' -a 'konfidens-e2e')
+    test_runner_client_token=$(security find-generic-password -w -s 'swift-provider-e2e' -a 'confidence-test')
 fi
 
 (cd $root_dir &&


### PR DESCRIPTION
As we are cleaning up older unused Confidence orgs and moving the testing setup to new ones