### PR TITLE
fix: add a default endpoint to the provider

### DIFF
--- a/Sources/ConfidenceProvider/ConfidenceClient/RemoteConfidenceClient.swift
+++ b/Sources/ConfidenceProvider/ConfidenceClient/RemoteConfidenceClient.swift
@@ -186,10 +186,10 @@ public enum ConfidenceClientCredentials {
     }
 }
 
-public enum ConfidenceRegion: String {
-    case global = "global"
-    case europe = "eu"
-    case usa = "us"
+public enum ConfidenceRegion {
+    case global
+    case europe
+    case usa
 }
 
 struct Sdk: Codable {

--- a/Sources/ConfidenceProvider/ConfidenceClient/RemoteConfidenceClient.swift
+++ b/Sources/ConfidenceProvider/ConfidenceClient/RemoteConfidenceClient.swift
@@ -171,7 +171,7 @@ public struct ConfidenceClientOptions {
     ) {
         self.credentials = credentials
         self.timeout = timeout ?? 10.0
-        self.region = region ?? .europe
+        self.region = region ?? .global
     }
 }
 
@@ -187,6 +187,7 @@ public enum ConfidenceClientCredentials {
 }
 
 public enum ConfidenceRegion: String {
+    case global = "global"
     case europe = "eu"
     case usa = "us"
 }

--- a/Sources/ConfidenceProvider/Http/NetworkClient.swift
+++ b/Sources/ConfidenceProvider/Http/NetworkClient.swift
@@ -8,11 +8,14 @@ final class NetworkClient: HttpClient {
     private let region: ConfidenceRegion
 
     private var baseUrl: String {
-        let region = region.rawValue
-        let domain = "confidence.dev"
-        let resolveRoute = "/v1/flags"
-
-        return "https://resolver.\(region).\(domain)\(resolveRoute)"
+        switch region {
+        case .global:
+            return "https://resolver.confidence.dev/v1/flags"
+        case .europe:
+            return "https://resolver.eu.confidence.dev/v1/flags"
+        case .usa:
+            return "https://resolver.us.confidence.dev/v1/flags"
+        }
     }
 
     init(

--- a/Tests/ConfidenceProviderTests/ConfidenceIntegrationTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceIntegrationTest.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import ConfidenceProvider
 
 class ConfidenceIntegrationTests: XCTestCase {
-    let clientToken: String? = "5GdaBq79NMVrMGXRVhN9g1pBKtG9cNK8"
+    let clientToken: String? = ProcessInfo.processInfo.environment["CLIENT_TOKEN"]
     let resolveFlag = setResolveFlag()
     let storage: Storage = StorageMock()
 

--- a/Tests/ConfidenceProviderTests/ConfidenceIntegrationTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceIntegrationTest.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import ConfidenceProvider
 
 class ConfidenceIntegrationTests: XCTestCase {
-    let clientToken: String? = ProcessInfo.processInfo.environment["CLIENT_TOKEN"]
+    let clientToken: String? = "5GdaBq79NMVrMGXRVhN9g1pBKtG9cNK8"
     let resolveFlag = setResolveFlag()
     let storage: Storage = StorageMock()
 

--- a/Tests/ConfidenceProviderTests/FlagApplierWithRetriesTest.swift
+++ b/Tests/ConfidenceProviderTests/FlagApplierWithRetriesTest.swift
@@ -197,7 +197,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
 
     func testApply_multipleApplyCalls_batchTriggered() async throws {
         // Given flag applier with http client that is offline
-        let httpClient = HttpClientMock(testMode: .error)
+        let httpClient = HttpClientMock(testMode: .offline)
         let networkExpectation = self.expectation(description: "Waiting for batch trigger")
         networkExpectation.expectedFulfillmentCount = 2
         httpClient.expectation = networkExpectation
@@ -237,7 +237,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
     func testApply_multipleApplyCalls_sentSet() async throws {
         // Given flag applier with http client that is offline
         let cacheDataInteractor = CacheDataInteractor(cacheData: .empty())
-        let offlineClient = HttpClientMock(testMode: .error)
+        let offlineClient = HttpClientMock(testMode: .offline)
         let networkExpectation = self.expectation(description: "Waiting for network call to complete")
         networkExpectation.expectedFulfillmentCount = 2
         offlineClient.expectation = networkExpectation
@@ -336,7 +336,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
     func testApply_previoslyStoredData_doesNotCleanAfterSendingFailure() throws {
         // Given offline http client
         // And storage that has previosly stored data (100 records, same token)
-        let offlineClient = HttpClientMock(testMode: .error)
+        let offlineClient = HttpClientMock(testMode: .offline)
         let prefilledStorage = StorageMock()
         let prefilledCache = try CacheDataUtility.prefilledCacheData(applyEventCount: 100)
         try prefilledStorage.save(data: prefilledCache)
@@ -359,7 +359,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
 
     func testApplyOffline_storesOnDisk() async throws {
         // Given offline http client and flag applier
-        let offlineClient = HttpClientMock(testMode: .error)
+        let offlineClient = HttpClientMock(testMode: .offline)
         let applier = FlagApplierWithRetries(
             httpClient: offlineClient, storage: storage, options: options, metadata: metadata, triggerBatch: false
         )
@@ -388,7 +388,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
 
     func testApplyOffline_storesOnDisk_multipleTokens() async throws {
         // Given offline http client and flag applier
-        let offlineClient = HttpClientMock(testMode: .error)
+        let offlineClient = HttpClientMock(testMode: .offline)
         let applier = FlagApplierWithRetries(
             httpClient: offlineClient, storage: storage, options: options, metadata: metadata, triggerBatch: false
         )
@@ -416,7 +416,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
     func testApplyOffline_previoslyStoredData_storesOnDisk() async throws {
         // Given flag applier set up with offline http client
         // And storage that has previously stored 1 record
-        let offlineClient = HttpClientMock(testMode: .error)
+        let offlineClient = HttpClientMock(testMode: .offline)
         let data = CacheData(resolveToken: "token0", flagName: "flag1", applyTime: Date(timeIntervalSince1970: 1000))
         let prefilledStorage = try StorageMock(data: data)
 
@@ -453,7 +453,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
     func testApplyOffline_previoslyStoredData_100records() async throws {
         // Given flag applier set up with offline http client
         // And storage that has previously stored 100 records with different tokens
-        let offlineClient = HttpClientMock(testMode: .error)
+        let offlineClient = HttpClientMock(testMode: .offline)
         let prefilledStorage = StorageMock()
         let prefilledCache = try CacheDataUtility.prefilledCacheData(resolveEventCount: 100)
         try prefilledStorage.save(data: prefilledCache)
@@ -477,7 +477,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
     func testApplyOffline_100applyCalls_sameToken() async throws {
         // Given flag applier set up with offline http client
         // And storage that has previously stored 100 records with same token
-        let offlineClient = HttpClientMock(testMode: .error)
+        let offlineClient = HttpClientMock(testMode: .offline)
         let networkExpectation = self.expectation(description: "Waiting for networkRequest to be completed")
 
         // Since we don't fail other requests when one request is failing

--- a/Tests/ConfidenceProviderTests/Helpers/HttpClientMock.swift
+++ b/Tests/ConfidenceProviderTests/Helpers/HttpClientMock.swift
@@ -12,7 +12,7 @@ final class HttpClientMock: HttpClient {
     enum TestMode {
         case success
         case failFirstChunk
-        case error
+        case offline
     }
 
     init(testMode: TestMode = .success) {
@@ -63,7 +63,7 @@ final class HttpClientMock: HttpClient {
             } else {
                 return HttpClientResponse(response: HTTPURLResponse())
             }
-        case .error:
+        case .offline:
             throw HttpClientError.invalidResponse
         }
     }


### PR DESCRIPTION
Previously, the region would default to Europe. This PR is changing this to GLOBAL and is specifying a URL for that.