### PR TITLE
fix: Fix FlagApplier async behaviour

### DIFF
--- a/Sources/ConfidenceProvider/Apply/FlagApplierWithRetries.swift
+++ b/Sources/ConfidenceProvider/Apply/FlagApplierWithRetries.swift
@@ -37,19 +37,19 @@ final class FlagApplierWithRetries: FlagApplier {
 
     public func apply(flagName: String, resolveToken: String) async {
         let applyTime = Date.backport.now
-        let (data, added) = await cacheDataInteractor.add(
+        async let (data, added) = await cacheDataInteractor.add(
             resolveToken: resolveToken,
             flagName: flagName,
             applyTime: applyTime
         )
-        guard added == true else {
+        guard await added == true else {
             // If record is found in the cache, early return (de-duplication).
             // Triggerring batch apply in case if there are any unsent events stored
             await triggerBatch()
             return
         }
 
-        self.writeToFile(data: data)
+        await self.writeToFile(data: data)
         await triggerBatch()
     }
 
@@ -57,7 +57,7 @@ final class FlagApplierWithRetries: FlagApplier {
 
     private func triggerBatch() async {
         async let cacheData = await cacheDataInteractor.cache
-        await cacheData.resolveEvents.forEach { resolveEvent in
+        await cacheData.resolveEvents.asyncForEach { resolveEvent in
             let appliesToSend = resolveEvent.events.filter { $0.status == .created }
                 .chunk(size: 20)
 
@@ -65,40 +65,38 @@ final class FlagApplierWithRetries: FlagApplier {
                 return
             }
 
-            appliesToSend.forEach { chunk in
-                self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .sending)
-                executeApply(
+            await appliesToSend.asyncForEach { chunk in
+                await self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .sending)
+                await executeApply(
                     resolveToken: resolveEvent.resolveToken,
                     items: chunk
                 ) { success in
                     guard success else {
-                        self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .created)
+                        await self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .created)
                         return
                     }
                     // Set 'sent' property of apply events to true
-                    self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .sent)
+                    await self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .sent)
                 }
             }
         }
     }
 
-    private func writeStatus(resolveToken: String, events: [FlagApply], status: ApplyEventStatus) {
+    private func writeStatus(resolveToken: String, events: [FlagApply], status: ApplyEventStatus) async {
         let lastIndex = events.count - 1
-        events.enumerated().forEach { index, event in
-            Task(priority: .medium) {
-                var data = await self.cacheDataInteractor.setEventStatus(
-                    resolveToken: resolveToken,
-                    name: event.name,
-                    status: status
-                )
+        await events.enumerated().asyncForEach { index, event in
+            var data = await self.cacheDataInteractor.setEventStatus(
+                resolveToken: resolveToken,
+                name: event.name,
+                status: status
+            )
 
-                if index == lastIndex {
-                    let unsentFlagApplies = data.resolveEvents.filter {
-                        $0.isSent == false
-                    }
-                    data.resolveEvents = unsentFlagApplies
-                    try? self.storage.save(data: data)
+            if index == lastIndex {
+                let unsentFlagApplies = data.resolveEvents.filter {
+                    $0.isSent == false
                 }
+                data.resolveEvents = unsentFlagApplies
+                try? self.storage.save(data: data)
             }
         }
     }
@@ -110,8 +108,8 @@ final class FlagApplierWithRetries: FlagApplier {
     private func executeApply(
         resolveToken: String,
         items: [FlagApply],
-        completion: @escaping (Bool) -> Void
-    ) {
+        completion: @escaping (Bool) async -> Void
+    ) async {
         let applyFlagRequestItems = items.map { applyEvent in
             AppliedFlagRequestItem(
                 flag: applyEvent.name,
@@ -126,25 +124,25 @@ final class FlagApplierWithRetries: FlagApplier {
             sdk: Sdk(id: metadata.name, version: metadata.version)
         )
 
-        performRequest(request: request) { result in
+        await performRequest(request: request) { result in
             switch result {
             case .success:
-                completion(true)
+                await completion(true)
             case .failure(let error):
                 self.logApplyError(error: error)
-                completion(false)
+                await completion(false)
             }
         }
     }
 
     private func performRequest(
         request: ApplyFlagsRequest,
-        completion: @escaping (ApplyFlagResult) -> Void
-    ) {
+        completion: @escaping (ApplyFlagResult) async -> Void
+    ) async {
         do {
-            try httpClient.post(path: ":apply", data: request, completion: completion)
+            try await httpClient.post(path: ":apply", data: request, completion: completion)
         } catch {
-            completion(.failure(handleError(error: error)))
+            await completion(.failure(handleError(error: error)))
         }
     }
 
@@ -165,6 +163,16 @@ final class FlagApplierWithRetries: FlagApplier {
         default:
             Logger(subsystem: "com.confidence.provider", category: "apply").error(
                 "Error while executing \"apply\": \(error)")
+        }
+    }
+}
+
+extension Sequence {
+    func asyncForEach(
+        _ transform: (Element) async throws -> Void
+    ) async rethrows {
+        for element in self {
+            try await transform(element)
         }
     }
 }

--- a/Sources/ConfidenceProvider/Http/HttpClient.swift
+++ b/Sources/ConfidenceProvider/Http/HttpClient.swift
@@ -6,8 +6,8 @@ protocol HttpClient {
     func post<T: Decodable>(
         path: String,
         data: Codable,
-        completion: @escaping (HttpClientResult<T>) -> Void
-    ) throws
+        completion: @escaping (HttpClientResult<T>) async -> Void
+    ) async throws
 
     func post<T: Decodable>(path: String, data: Codable) async throws -> HttpClientResponse<T>
 }

--- a/Tests/ConfidenceProviderTests/CacheDataInteractorTests.swift
+++ b/Tests/ConfidenceProviderTests/CacheDataInteractorTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import ConfidenceProvider
 
 final class CacheDataInteractorTests: XCTestCase {
-    func testCacheDataInteractor_loadsEventsFromStorage() throws {
+    func testCacheDataInteractor_loadsEventsFromStorage() async throws {
         // Given prefilled storage with 10 resolve events (20 apply events in each)
         let prefilledCache = try CacheDataUtility.prefilledCacheData(
             resolveEventCount: 10,
@@ -16,30 +16,25 @@ final class CacheDataInteractorTests: XCTestCase {
         let cacheDataInteractor = CacheDataInteractor(cacheData: prefilledCache)
 
         // Then cache data is loaded from storage
-        Task {
-            // Wrapped it in the Task in order to ensure that async code is completed before assertions
-            let cache = await cacheDataInteractor.cache
-            XCTAssertEqual(cache.resolveEvents.count, 10)
-            XCTAssertEqual(cache.resolveEvents.last?.events.count, 20)
-        }
+        let cache = await cacheDataInteractor.cache
+        XCTAssertEqual(cache.resolveEvents.count, 10)
+        XCTAssertEqual(cache.resolveEvents.last?.events.count, 20)
     }
 
     func testCacheDataInteractor_addEventToEmptyCache() async throws {
         // Given cache data interactor with no previously stored data
         let cacheDataInteractor = CacheDataInteractor(cacheData: .empty())
-        Task {
-            let cache = await cacheDataInteractor.cache
-            XCTAssertEqual(cache.resolveEvents.count, 0)
-        }
 
-        Task {
-            // When cache data add method is called
-            _ = await cacheDataInteractor.add(resolveToken: "token", flagName: "name", applyTime: Date())
+        let cache = await cacheDataInteractor.cache
+        XCTAssertEqual(cache.resolveEvents.count, 0)
 
-            // Then event is added with
-            let cache = await cacheDataInteractor.cache
-            XCTAssertEqual(cache.resolveEvents.count, 1)
-        }
+
+        // When cache data add method is called
+        _ = await cacheDataInteractor.add(resolveToken: "token", flagName: "name", applyTime: Date())
+
+        // Then event is added with
+        let cache2 = await cacheDataInteractor.cache
+        XCTAssertEqual(cache2.resolveEvents.count, 1)
     }
 
     func testCacheDataInteractor_addEventToPreFilledCache() async throws {
@@ -47,13 +42,11 @@ final class CacheDataInteractorTests: XCTestCase {
         let prefilledCacheData = try CacheDataUtility.prefilledCacheData(applyEventCount: 2)
         let cacheDataInteractor = CacheDataInteractor(cacheData: prefilledCacheData)
 
-        Task {
-            // When cache data add method is called
-            _ = await cacheDataInteractor.add(resolveToken: "token", flagName: "name", applyTime: Date())
+        // When cache data add method is called
+        _ = await cacheDataInteractor.add(resolveToken: "token", flagName: "name", applyTime: Date())
 
-            // Then event is added with
-            let cache = await cacheDataInteractor.cache
-            XCTAssertEqual(cache.resolveEvents.count, 2)
-        }
+        // Then event is added with
+        let cache = await cacheDataInteractor.cache
+        XCTAssertEqual(cache.resolveEvents.count, 2)
     }
 }

--- a/Tests/ConfidenceProviderTests/Helpers/HttpClientMock.swift
+++ b/Tests/ConfidenceProviderTests/Helpers/HttpClientMock.swift
@@ -22,13 +22,13 @@ final class HttpClientMock: HttpClient {
     func post<T>(
         path: String,
         data: Codable,
-        completion: @escaping (ConfidenceProvider.HttpClientResult<T>) -> Void
-    ) throws where T: Decodable {
+        completion: @escaping (ConfidenceProvider.HttpClientResult<T>) async -> Void
+    ) async throws where T: Decodable {
         do {
             let result: HttpClientResponse<T> = try handlePost(path: path, data: data)
-            completion(.success(result))
+            await completion(.success(result))
         } catch {
-            completion(.failure(error))
+            await completion(.failure(error))
         }
     }
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -15,6 +15,7 @@ fi
 
 (cd $root_dir &&
     TEST_RUNNER_CLIENT_TOKEN=$test_runner_client_token TEST_RUNNER_TEST_FLAG_NAME=$2 xcodebuild \
+        -quiet \
         -scheme ConfidenceProvider \
         -sdk "iphonesimulator" \
         -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' \


### PR DESCRIPTION
Issues with flaky tests seem to be caused by the async `apply` function in `FlagApplier` not really waiting for the entire triggerBatch operation to finish (including network + updating the cache for apply status), before returning.

Note: older context around the existing asynchronous setup: https://github.com/spotify/confidence-openfeature-provider-swift/pull/35 (not sure how much this is relevant for this PR)