### PR TITLE
refactor: Remove callbacks from HttpClient

### DIFF
--- a/Sources/ConfidenceProvider/Http/HttpClient.swift
+++ b/Sources/ConfidenceProvider/Http/HttpClient.swift
@@ -3,13 +3,7 @@ import Foundation
 typealias HttpClientResult<T> = Result<HttpClientResponse<T>, Error>
 
 protocol HttpClient {
-    func post<T: Decodable>(
-        path: String,
-        data: Codable,
-        completion: @escaping (HttpClientResult<T>) async -> Void
-    ) async throws
-
-    func post<T: Decodable>(path: String, data: Codable) async throws -> HttpClientResponse<T>
+    func post<T: Decodable>(path: String, data: Codable) async throws -> HttpClientResult<T>
 }
 
 struct HttpClientResponse<T> {

--- a/Tests/ConfidenceProviderTests/Helpers/HttpClientMock.swift
+++ b/Tests/ConfidenceProviderTests/Helpers/HttpClientMock.swift
@@ -19,34 +19,13 @@ final class HttpClientMock: HttpClient {
         self.testMode = testMode
     }
 
-    func post<T>(
-        path: String,
-        data: Codable,
-        completion: @escaping (ConfidenceProvider.HttpClientResult<T>) async -> Void
-    ) async throws where T: Decodable {
-        do {
-            let result: HttpClientResponse<T> = try handlePost(path: path, data: data)
-            await completion(.success(result))
-        } catch {
-            await completion(.failure(error))
-        }
-    }
-
-    func post<T>(
-        path: String, data: Codable
-    ) async throws -> ConfidenceProvider.HttpClientResponse<T> where T: Decodable {
-        try handlePost(path: path, data: data)
-    }
-
-    func post<T>(
-        path: String, data: Codable
-    ) throws -> ConfidenceProvider.HttpClientResponse<T> where T: Decodable {
+    func post<T>(path: String, data: Codable) async throws -> ConfidenceProvider.HttpClientResult<T> where T: Decodable {
         try handlePost(path: path, data: data)
     }
 
     private func handlePost<T>(
         path: String, data: Codable
-    ) throws -> ConfidenceProvider.HttpClientResponse<T> where T: Decodable {
+    ) throws -> ConfidenceProvider.HttpClientResult<T> where T: Decodable {
         defer {
             expectation?.fulfill()
         }
@@ -56,12 +35,12 @@ final class HttpClientMock: HttpClient {
 
         switch testMode {
         case .success:
-            return HttpClientResponse(response: HTTPURLResponse())
+            return .success(HttpClientResponse(response: HTTPURLResponse()))
         case .failFirstChunk:
             if postCallCounter == 1 {
                 throw HttpClientError.invalidResponse
             } else {
-                return HttpClientResponse(response: HTTPURLResponse())
+                return .success(HttpClientResponse(response: HTTPURLResponse()))
             }
         case .offline:
             throw HttpClientError.invalidResponse


### PR DESCRIPTION
Streamline the network implementation to use async/await across the entire stack.