### PR TITLE
fix: Remove STALE event

### DIFF
--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -47,7 +47,6 @@ public class ConfidenceFeatureProvider: FeatureProvider {
             return
         }
 
-        // signal the provider is ready right away
         if self.initializationStrategy == .activateAndFetchAsync {
             OpenFeatureAPI.shared.emitEvent(.ready, provider: self)
         }
@@ -178,8 +177,6 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     }
 
     private func resolve(context: OpenFeature.EvaluationContext) async throws -> ResolvesResult {
-        // Racy: eval ctx and ctx in cache might differ until the latter is updated, resulting in STALE evaluations
-        OpenFeatureAPI.shared.emitEvent(.stale, provider: self)
         do {
             let resolveResult = try await client.resolve(ctx: context)
             return resolveResult


### PR DESCRIPTION
The reasons behind this change:
- This is currently not working as expected, since in case of `activateAndFetchAsync` the STALE event is emitted even if it shouldn't
- According to [this WIP Proposal](https://github.com/open-feature/spec/pull/241/files), no event is expected prior to "initialize". 
- The STALE event is not meant to indicate a "not-ready cache" anyway: it's meant be used only if the system detects a change of flag evaluation data (for the same evaluation context). From the same PR mentioned above, a new events will be introduced for context reconciliation: `PROVIDER_CONTEXT_PENDING` and `PROVIDER_CONTEXT_CHANGED` 