### PR TITLE
fix: change STALE reason in case of context change

### DIFF
--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -251,8 +251,12 @@ public class ConfidenceFeatureProvider: FeatureProvider {
             )
             return evaluationResult
         } catch ConfidenceError.cachedValueExpired {
-            return ProviderEvaluation(value: defaultValue, variant: nil, reason: Reason.stale.rawValue)
-        } catch {
+            return ProviderEvaluation(value: defaultValue,
+                                      variant: nil, 
+                                      reason: Reason.error.rawValue,
+                                      errorCode: ErrorCode.providerNotReady
+            )}
+        catch {
             throw error
         }
     }

--- a/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
@@ -347,10 +347,10 @@ class ConfidenceFeatureProviderTest: XCTestCase {
                 context: MutableContext(targetingKey: "user1"))
 
             XCTAssertEqual(evaluation.value, 0)
-            XCTAssertNil(evaluation.errorCode)
             XCTAssertNil(evaluation.errorMessage)
             XCTAssertNil(evaluation.variant)
-            XCTAssertEqual(evaluation.reason, Reason.stale.rawValue)
+            XCTAssertEqual(evaluation.errorCode, ErrorCode.providerNotReady)
+            XCTAssertEqual(evaluation.reason, Reason.error.rawValue)
             XCTAssertEqual(MockedConfidenceClientURLProtocol.resolveStats, 1)
 
             // TODO: Check this - how do we check for something not called?


### PR DESCRIPTION
Previously, the provider would emit STALE if the evaluation context changed and the cache has been populated with default values due to fetch request not being finished. We believe that trying to access cache too early is an error on the user's side and should be communicated as an ERROR and not STALE.