### PR TITLE
feat: Return previous value on Provider STALE

### DIFF
--- a/Sources/ConfidenceProvider/ConfidenceClient/ConfidenceClient.swift
+++ b/Sources/ConfidenceProvider/ConfidenceClient/ConfidenceClient.swift
@@ -18,6 +18,7 @@ public struct ResolvedValue: Codable, Equatable {
         case targetingKeyError = 2
         case generalError = 3
         case disabled = 4
+        case stale = 5
     }
 }
 

--- a/Sources/ConfidenceProvider/ConfidenceClient/LocalStorageResolver.swift
+++ b/Sources/ConfidenceProvider/ConfidenceClient/LocalStorageResolver.swift
@@ -16,8 +16,8 @@ public class LocalStorageResolver: Resolver {
             throw OpenFeatureError.flagNotFoundError(key: flag)
         }
         guard getResult.needsUpdate == false else {
-            throw ConfidenceError.cachedValueExpired
+            return .init(resolvedValue: getResult.resolvedValue, resolveToken: getResult.resolveToken, stale: true)
         }
-        return .init(resolvedValue: getResult.resolvedValue, resolveToken: getResult.resolveToken)
+        return .init(resolvedValue: getResult.resolvedValue, resolveToken: getResult.resolveToken, stale: false)
     }
 }

--- a/Sources/ConfidenceProvider/ConfidenceClient/LocalStorageResolver.swift
+++ b/Sources/ConfidenceProvider/ConfidenceClient/LocalStorageResolver.swift
@@ -16,8 +16,10 @@ public class LocalStorageResolver: Resolver {
             throw OpenFeatureError.flagNotFoundError(key: flag)
         }
         guard getResult.needsUpdate == false else {
-            return .init(resolvedValue: getResult.resolvedValue, resolveToken: getResult.resolveToken, stale: true)
+            var resolveValueStale = getResult.resolvedValue
+            resolveValueStale.resolveReason = .stale
+            return .init(resolvedValue: resolveValueStale, resolveToken: getResult.resolveToken)
         }
-        return .init(resolvedValue: getResult.resolvedValue, resolveToken: getResult.resolveToken, stale: false)
+        return .init(resolvedValue: getResult.resolvedValue, resolveToken: getResult.resolveToken)
     }
 }

--- a/Sources/ConfidenceProvider/ConfidenceClient/Resolver.swift
+++ b/Sources/ConfidenceProvider/ConfidenceClient/Resolver.swift
@@ -8,4 +8,5 @@ public protocol Resolver {
 public struct ResolveResult {
     var resolvedValue: ResolvedValue
     var resolveToken: String?
+    var stale: Bool
 }

--- a/Sources/ConfidenceProvider/ConfidenceClient/Resolver.swift
+++ b/Sources/ConfidenceProvider/ConfidenceClient/Resolver.swift
@@ -8,5 +8,4 @@ public protocol Resolver {
 public struct ResolveResult {
     var resolvedValue: ResolvedValue
     var resolveToken: String?
-    var stale: Bool
 }

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -276,6 +276,11 @@ public class ConfidenceFeatureProvider: FeatureProvider {
         }
 
         if resolverResult.stale {
+            processResultForApply(
+                resolverResult: resolverResult,
+                ctx: ctx,
+                applyTime: Date.backport.now
+            )
             return ProviderEvaluation(
                 value: typedValue,
                 variant: resolverResult.resolvedValue.variant,

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -289,11 +289,7 @@ public class ConfidenceFeatureProvider: FeatureProvider {
             )
             return evaluationResult
         } catch ConfidenceError.cachedValueExpired {
-            return ProviderEvaluation(
-                value: defaultValue,
-                variant: nil,
-                reason: Reason.error.rawValue,
-                errorCode: ErrorCode.providerNotReady)
+            return ProviderEvaluation(value: defaultValue, variant: nil, reason: Reason.stale.rawValue)
         } catch {
             throw error
         }

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -275,23 +275,11 @@ public class ConfidenceFeatureProvider: FeatureProvider {
             throw OpenFeatureError.parseError(message: "Unable to parse flag value: \(pathValue)")
         }
 
-        if resolverResult.resolvedValue.resolveReason == .stale {
-            processResultForApply(
-                resolverResult: resolverResult,
-                ctx: ctx,
-                applyTime: Date.backport.now
-            )
-            return ProviderEvaluation(
-                value: typedValue,
-                variant: resolverResult.resolvedValue.variant,
-                reason: Reason.stale.rawValue
-            )
-        }
-
+        let isStale = resolverResult.resolvedValue.resolveReason == .stale
         let evaluationResult = ProviderEvaluation(
             value: typedValue,
             variant: resolverResult.resolvedValue.variant,
-            reason: Reason.targetingMatch.rawValue
+            reason: isStale ? Reason.stale.rawValue : Reason.targetingMatch.rawValue
         )
 
         processResultForApply(

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -275,7 +275,7 @@ public class ConfidenceFeatureProvider: FeatureProvider {
             throw OpenFeatureError.parseError(message: "Unable to parse flag value: \(pathValue)")
         }
 
-        if resolverResult.stale {
+        if resolverResult.resolvedValue.resolveReason == .stale {
             processResultForApply(
                 resolverResult: resolverResult,
                 ctx: ctx,
@@ -341,6 +341,12 @@ public class ConfidenceFeatureProvider: FeatureProvider {
                 reason: Reason.error.rawValue,
                 errorCode: ErrorCode.general,
                 errorMessage: "General error in the Confidence backend")
+        case .stale:
+            return ProviderEvaluation(
+                value: defaultValue,
+                variant: resolverResult.resolvedValue.variant,
+                reason: Reason.stale.rawValue
+            )
         }
     }
 

--- a/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
@@ -312,7 +312,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
 
     func testStaleEvaluationContextInCache() throws {
         let resolve: [String: MockedResolveClientURLProtocol.ResolvedTestFlag] = [
-            "user1": .init(variant: "control", value: .structure(["size": .integer(3)]))
+            "user0": .init(variant: "control", value: .structure(["size": .integer(3)]))
         ]
 
         let flags: [String: MockedResolveClientURLProtocol.TestFlag] = [
@@ -320,17 +320,10 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         ]
 
         let session = MockedResolveClientURLProtocol.mockedSession(flags: flags)
-        // Simulating a cache with an old evaluation context
-
-        let data = [ResolvedValue(flag: "flag", resolveReason: .match)]
-            .toCacheData(context: MutableContext(targetingKey: "user0"), resolveToken: "token0")
-
-        let storage = try StorageMock(data: data)
 
         let provider =
         builder
             .with(session: session)
-            .with(storage: storage)
             .build()
         try withExtendedLifetime(
             provider.observe().sink { event in
@@ -347,10 +340,10 @@ class ConfidenceFeatureProviderTest: XCTestCase {
                 defaultValue: 0,
                 context: MutableContext(targetingKey: "user1"))
 
-            XCTAssertEqual(evaluation.value, 0)
+            XCTAssertEqual(evaluation.value, 3)
             XCTAssertNil(evaluation.errorCode)
             XCTAssertNil(evaluation.errorMessage)
-            XCTAssertNil(evaluation.variant)
+            XCTAssertEqual(evaluation.variant, "control")
             XCTAssertEqual(evaluation.reason, Reason.stale.rawValue)
             XCTAssertEqual(MockedResolveClientURLProtocol.resolveStats, 1)
             // TODO: Check this - how do we check for something not called?

--- a/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
@@ -348,12 +348,11 @@ class ConfidenceFeatureProviderTest: XCTestCase {
                 context: MutableContext(targetingKey: "user1"))
 
             XCTAssertEqual(evaluation.value, 0)
+            XCTAssertNil(evaluation.errorCode)
             XCTAssertNil(evaluation.errorMessage)
             XCTAssertNil(evaluation.variant)
-            XCTAssertEqual(evaluation.errorCode, ErrorCode.providerNotReady)
-            XCTAssertEqual(evaluation.reason, Reason.error.rawValue)
+            XCTAssertEqual(evaluation.reason, Reason.stale.rawValue)
             XCTAssertEqual(MockedResolveClientURLProtocol.resolveStats, 1)
-
             // TODO: Check this - how do we check for something not called?
             XCTAssertEqual(flagApplier.applyCallCount, 0)
         }

--- a/Tests/ConfidenceProviderTests/Helpers/ClientMock.swift
+++ b/Tests/ConfidenceProviderTests/Helpers/ClientMock.swift
@@ -48,6 +48,6 @@ class ClientMock: ConfidenceResolveClient {
     }
 
     func resolve(flag: String, ctx: EvaluationContext) throws -> ResolveResult {
-        return ResolveResult(resolvedValue: ResolvedValue(flag: "flag1", resolveReason: .match), resolveToken: "")
+        return ResolveResult(resolvedValue: ResolvedValue(flag: "flag1", resolveReason: .match), resolveToken: "", stale: false)
     }
 }

--- a/Tests/ConfidenceProviderTests/Helpers/ClientMock.swift
+++ b/Tests/ConfidenceProviderTests/Helpers/ClientMock.swift
@@ -50,8 +50,7 @@ class ClientMock: ConfidenceResolveClient {
     func resolve(flag: String, ctx: EvaluationContext) throws -> ResolveResult {
         return ResolveResult(
             resolvedValue: ResolvedValue(flag: "flag1", resolveReason: .match),
-            resolveToken: "",
-            stale: false
+            resolveToken: ""
         )
     }
 }

--- a/Tests/ConfidenceProviderTests/Helpers/ClientMock.swift
+++ b/Tests/ConfidenceProviderTests/Helpers/ClientMock.swift
@@ -48,6 +48,10 @@ class ClientMock: ConfidenceResolveClient {
     }
 
     func resolve(flag: String, ctx: EvaluationContext) throws -> ResolveResult {
-        return ResolveResult(resolvedValue: ResolvedValue(flag: "flag1", resolveReason: .match), resolveToken: "", stale: false)
+        return ResolveResult(
+            resolvedValue: ResolvedValue(flag: "flag1", resolveReason: .match),
+            resolveToken: "",
+            stale: false
+        )
     }
 }

--- a/Tests/ConfidenceProviderTests/LocalStorageResolverTest.swift
+++ b/Tests/ConfidenceProviderTests/LocalStorageResolverTest.swift
@@ -12,12 +12,9 @@ class LocalStorageResolverTest: XCTestCase {
         let resolver = LocalStorageResolver(cache: cache)
 
         let ctx = MutableContext(targetingKey: "key", structure: MutableStructure())
-        XCTAssertThrowsError(
+        XCTAssertNoThrow(
             try resolver.resolve(flag: "test", ctx: ctx)
-        ) { error in
-            XCTAssertEqual(
-                error as? ConfidenceError, ConfidenceError.cachedValueExpired)
-        }
+        )
     }
 
     func testMissingValueFromCache() throws {


### PR DESCRIPTION
After a discussion within the team, it has been decided that when context is updated and provider is stale (hasn't resolved with new evaluation context / is about to resolve), in the meantime we would return previous value.