### PR TITLE
refactor: Add message container to payload

### DIFF
--- a/ConfidenceDemoApp/ConfidenceDemoApp/ConfidenceDemoApp.swift
+++ b/ConfidenceDemoApp/ConfidenceDemoApp/ConfidenceDemoApp.swift
@@ -41,8 +41,8 @@ extension ConfidenceDemoApp {
             await OpenFeatureAPI.shared.setProviderAndWait(provider: provider, initialContext: ctx)
         }
         confidence.send(
-            definition: "all-types",
-            payload: [
+            eventName: "all-types",
+            message: [
                 "my_string": ConfidenceValue(string: "hello_from_world"),
                 "my_timestamp": ConfidenceValue(timestamp: Date()),
                 "my_bool": ConfidenceValue(boolean: true),

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -28,8 +28,8 @@ public class Confidence: ConfidenceEventSender {
         self.parent = parent
     }
 
-    public func send(definition: String, payload: ConfidenceStruct) {
-        eventSenderEngine.emit(definition: definition, payload: payload, context: getContext())
+    public func send(eventName: String, message: ConfidenceStruct) {
+        eventSenderEngine.emit(eventName: eventName, message: message, context: getContext())
     }
 
 

--- a/Sources/Confidence/ConfidenceEventSender.swift
+++ b/Sources/Confidence/ConfidenceEventSender.swift
@@ -2,5 +2,5 @@ import Foundation
 
 /// Sends events to Confidence. Contextual data is appended to each event
 public protocol ConfidenceEventSender: Contextual {
-    func send(definition: String, payload: ConfidenceStruct)
+    func send(eventName: String, message: ConfidenceStruct)
 }

--- a/Sources/Confidence/EventSenderEngine.swift
+++ b/Sources/Confidence/EventSenderEngine.swift
@@ -79,11 +79,11 @@ final class EventSenderEngineImpl: EventSenderEngine {
     }
 
     func emit(eventName: String, message: ConfidenceStruct, context: ConfidenceStruct) {
+        var mutablePayload = context
+        mutablePayload["message"] = ConfidenceValue(structure: message)
         writeReqChannel.send(ConfidenceEvent(
             name: eventName,
-            payload: context.merging(message) { _, new in
-                new
-            },
+            payload: mutablePayload,
             eventTime: Date.backport.now)
         )
     }

--- a/Sources/Confidence/EventSenderEngine.swift
+++ b/Sources/Confidence/EventSenderEngine.swift
@@ -9,7 +9,7 @@ protocol FlushPolicy {
 }
 
 protocol EventSenderEngine {
-    func emit(definition: String, payload: ConfidenceStruct, context: ConfidenceStruct)
+    func emit(eventName: String, message: ConfidenceStruct, context: ConfidenceStruct)
     func shutdown()
 }
 
@@ -78,10 +78,10 @@ final class EventSenderEngineImpl: EventSenderEngine {
         .store(in: &cancellables)
     }
 
-    func emit(definition: String, payload: ConfidenceStruct, context: ConfidenceStruct) {
+    func emit(eventName: String, message: ConfidenceStruct, context: ConfidenceStruct) {
         writeReqChannel.send(ConfidenceEvent(
-            name: definition,
-            payload: context.merging(payload) { _, new in
+            name: eventName,
+            payload: context.merging(message) { _, new in
                 new
             },
             eventTime: Date.backport.now)

--- a/Tests/ConfidenceTests/EventSenderEngineTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineTest.swift
@@ -59,7 +59,7 @@ final class EventSenderEngineTest: XCTestCase {
                 payload: [:],
                 eventTime: Date.backport.now)
             )
-            eventSenderEngine.emit(definition: "\(i)", payload: [:], context: [:])
+            eventSenderEngine.emit(eventName: "\(i)", message: [:], context: [:])
         }
 
         wait(for: [expectation], timeout: 5)
@@ -67,7 +67,7 @@ final class EventSenderEngineTest: XCTestCase {
         XCTAssertTrue(uploadRequest.map { $0.eventDefinition } == events.map { $0.name })
 
         uploader.reset()
-        eventSenderEngine.emit(definition: "Hello", payload: [:], context: [:])
+        eventSenderEngine.emit(eventName: "Hello", message: [:], context: [:])
         XCTAssertNil(uploader.calledRequest)
         cancellable.cancel()
     }
@@ -87,7 +87,7 @@ final class EventSenderEngineTest: XCTestCase {
             storage: storage,
             flushPolicies: flushPolicies
         )
-        eventSenderEngine.emit(definition: "testEvent", payload: ConfidenceStruct(), context: ConfidenceStruct())
+        eventSenderEngine.emit(eventName: "testEvent", message: ConfidenceStruct(), context: ConfidenceStruct())
         let expectation = expectation(description: "events batched")
         storage.eventsRemoved{
             expectation.fulfill()
@@ -113,7 +113,7 @@ final class EventSenderEngineTest: XCTestCase {
             flushPolicies: flushPolicies
         )
 
-        eventSenderEngine.emit(definition: "testEvent", payload: ConfidenceStruct(), context: ConfidenceStruct())
+        eventSenderEngine.emit(eventName: "testEvent", message: ConfidenceStruct(), context: ConfidenceStruct())
 
         XCTAssertEqual(storage.isEmpty(), false)
     }

--- a/Tests/ConfidenceTests/EventSenderEngineTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineTest.swift
@@ -58,8 +58,8 @@ final class EventSenderEngineTest: XCTestCase {
         eventSenderEngine.emit(
             eventName: "my_event",
             message: [
-                "a":.init(integer: 0),
-                "message":.init(integer: 1),
+                "a": .init(integer: 0),
+                "message": .init(integer: 1),
             ],
             context: [
                 "a": .init(integer: 2),
@@ -68,15 +68,15 @@ final class EventSenderEngineTest: XCTestCase {
 
 
         wait(for: [expectation], timeout: 5)
-        let uploadRequest = try XCTUnwrap(uploader.calledRequest)
-        XCTAssertEqual(uploader.calledRequest![0].eventDefinition, "my_event")
-        XCTAssertEqual(uploader.calledRequest![0].payload, NetworkStruct(fields: [
+        XCTAssertEqual(try XCTUnwrap(uploader.calledRequest)[0].eventDefinition, "my_event")
+        XCTAssertEqual(try XCTUnwrap(uploader.calledRequest)[0].payload, NetworkStruct(fields: [
             "message": .structure(.init(fields: [
-                "a" : .number(0.0),
+                "a": .number(0.0),
                 "message": .number(1.0)
             ])),
             "a": .number(2.0)
         ]))
+        cancellable.cancel()
     }
 
     func testAddingEventsWithSizeFlushPolicyWorks() throws {

--- a/Tests/ConfidenceTests/Helpers/EventSenderEngineMock.swift
+++ b/Tests/ConfidenceTests/Helpers/EventSenderEngineMock.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import Confidence
 
 class EventSenderEngineMock: EventSenderEngine {
-    func emit(definition: String, payload: ConfidenceStruct, context: ConfidenceStruct) {
+    func emit(eventName: String, message: ConfidenceStruct, context: ConfidenceStruct) {
         // NO-OP
     }
 


### PR DESCRIPTION
Signature is:
```
public func send(eventName: String, message: ConfidenceStruct) { ... }
```