### PR TITLE
fix: Provider cache and resolver are accessed safely

### DIFF
--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -50,7 +50,6 @@ public class Confidence: ConfidenceEventSender {
         }
     }
 
-
     public func getContext() -> ConfidenceStruct {
         let parentContext = parent?.getContext() ?? [:]
         var reconciledCtx = parentContext.filter {

--- a/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
@@ -340,6 +340,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
     }
 
     func testResolveAndApplyIntegerFlagError() throws {
+        flagApplier = FlagApplierMock(expectedApplies: 2)
         let resolve: [String: MockedResolveClientURLProtocol.ResolvedTestFlag] = [
             "user1": .init(variant: "control", value: .structure(["size": .integer(3)]))
         ]

--- a/Tests/ConfidenceProviderTests/Helpers/FlagApplierMock.swift
+++ b/Tests/ConfidenceProviderTests/Helpers/FlagApplierMock.swift
@@ -7,6 +7,10 @@ class FlagApplierMock: FlagApplier {
     var applyCallCount = 0
     var applyExpectation = XCTestExpectation(description: "Flag Applied")
 
+    init(expectedApplies: Int = 1) {
+        applyExpectation.expectedFulfillmentCount = expectedApplies
+    }
+
     func apply(flagName: String, resolveToken: String) async {
         applyCallCount += 1
         applyExpectation.fulfill()


### PR DESCRIPTION
Flaky test, but could reproduce this every 3/4 runs:
<img width="1821" alt="Screenshot 2024-04-29 at 16 10 12" src="https://github.com/spotify/confidence-openfeature-provider-swift/assets/7601824/96549bf5-dff9-4ffa-a764-da4b4eb7172d">
