### PR TITLE
fix: Reconciliation bug

### DIFF
--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -88,6 +88,7 @@ public class Confidence: ConfidenceEventSender {
             var map = confidence.contextFlow.value
             for removedKey in removedKeys {
                 map.removeValue(forKey: removedKey)
+                confidence.removedContextKeys.insert(removedKey)
             }
             for entry in context {
                 map.updateValue(entry.value, forKey: entry.key)

--- a/Sources/Confidence/Contextual.swift
+++ b/Sources/Confidence/Contextual.swift
@@ -9,6 +9,7 @@ public protocol Contextual: ConfidenceContextProvider {
     /// Removes entry from local data
     /// It hides entries with this key from parents' data (without modifying parents' data)
     func removeContextEntry(key: String)
+    func putContext(context: ConfidenceStruct, removedKeys: [String])
     /// Creates a child Contextual instance that maintains access to its parent's data
     func withContext(_ context: ConfidenceStruct) -> Self
 }

--- a/Tests/ConfidenceTests/ConfidenceTests.swift
+++ b/Tests/ConfidenceTests/ConfidenceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Confidence
 
+// swiftlint:disable type_body_length
 final class ConfidenceTests: XCTestCase {
     func testWithContext() {
         let confidenceParent = Confidence.init(
@@ -39,6 +40,30 @@ final class ConfidenceTests: XCTestCase {
             value: ConfidenceValue(string: "v3"))
         let expected = [
             "k1": ConfidenceValue(string: "v1"),
+            "k2": ConfidenceValue(string: "v2"),
+            "k3": ConfidenceValue(string: "v3"),
+        ]
+        XCTAssertEqual(confidenceChild.getContext(), expected)
+    }
+
+    func testWithContextUpdateParentRemoveKeys() {
+        let confidenceParent = Confidence.init(
+            clientSecret: "",
+            timeout: TimeInterval(),
+            region: .europe,
+            eventSenderEngine: EventSenderEngineMock(),
+            initializationStrategy: .activateAndFetchAsync,
+            context: ["k1": ConfidenceValue(string: "v1")],
+            parent: nil
+        )
+        let confidenceChild: ConfidenceEventSender = confidenceParent.withContext(
+            ["k2": ConfidenceValue(string: "v2")]
+        )
+        confidenceChild.putContext(
+            context: ["k3": ConfidenceValue(string: "v3")],
+            removedKeys: ["k1"]
+        )
+        let expected = [
             "k2": ConfidenceValue(string: "v2"),
             "k3": ConfidenceValue(string: "v3"),
         ]
@@ -246,3 +271,4 @@ final class ConfidenceTests: XCTestCase {
         XCTAssertNil(confidence.getContext()["visitorId"])
     }
 }
+// swiftlint:enable type_body_length


### PR DESCRIPTION
Exposing `func putContext(context: ConfidenceStruct, removedKeys: [String])` in the public protocol was the easiest way to test its behaviour